### PR TITLE
Create subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::SubscriptionsController < ApplicationController
+  def create
+    customer_data = Customer.find_by(email: params[:email])
+    tea_data = Tea.find(params[:tea_id])
+    if customer_data.valid? && tea_data.valid?
+      sub = Subscription.create(title: tea_data.title, price: 10, frequency: 1, customer_id: customer_data.id, tea_id: tea_data.id)
+      render json: SubscriptionSerializer.new(sub), status: :accepted
+    else
+      render json: SubscriptionSerializer.error("Subscription could not be created!")
+    end
+  end
+end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,0 +1,4 @@
+class SubscriptionSerializer
+  include JSONAPI::Serializer
+  attributes :id, :title, :price, :status, :frequency
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :subscriptions, only: [:create]
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2022_04_20_032139) do
   create_table "teas", force: :cascade do |t|
     t.string "title"
     t.string "description"
-    t.float "temperature"
+    t.integer "temperature"
     t.integer "brew_time"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Customer.destroy_all
+Tea.destroy_all
+Subscription.destroy_all
 
 c1 = Customer.create(first_name: "Test", last_name: "Person1", email: "test@person1.com", address: "12345 Something Road")
 c2 = Customer.create(first_name: "Test", last_name: "Person2", email: "test@person2.com", address: "12345 Something Road")

--- a/spec/requests/subscription_request_spec.rb
+++ b/spec/requests/subscription_request_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Subscription API Endpoints' do
+  describe 'POST /subscription' do
+    it 'creates a new subscription for a customer' do
+      user_data = "test@person1.com"
+      tea_data = 1
+      c1 = Customer.create(first_name: "Test", last_name: "Person1", email: "test@person1.com", address: "12345 Something Road")
+      t1 = Tea.create(title: "Earl Grey", description: "Black Tea", temperature: 110, brew_time: 3)
+      post '/api/v1/subscriptions', params: { email: c1.email, tea_id: t1.id }
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+
+      expect(result).to be_a Hash
+      expect(result[:data]).to be_a Hash
+
+      expect(result[:data]).to have_key(:id)
+
+      expect(result[:data]).to have_key(:type)
+      expect(result[:data][:type]).to eq("subscription")
+
+      expect(result[:data]).to have_key(:attributes)
+
+      expect(result[:data][:attributes]).to have_key(:id)
+      expect(result[:data][:attributes]).to have_key(:title)
+      expect(result[:data][:attributes]).to have_key(:price)
+      expect(result[:data][:attributes]).to have_key(:status)
+      expect(result[:data][:attributes]).to have_key(:frequency)
+      expect(result[:data][:attributes][:title]).to eq(t1.title)
+    end
+  end
+end


### PR DESCRIPTION
## Changes include: 
- Exposes a new endpoint to create a subscription with the following format: 
- `POST '/api/v1/subscriptions'`
```json
{
  "email": "<email_address>",
  "tea_id": "<tea_id>"
}
```