### PR TITLE
Active subscriptions

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,4 +1,16 @@
 class Api::V1::SubscriptionsController < ApplicationController
+  def index
+    customer = Customer.find(params[:customer_id])
+    if params[:status] == "active"
+      subs = customer.get_active_subscriptions
+    elsif params[:status] == "cancelled"
+      subs = customer.get_cancelled_subscriptions
+    else
+      subs = customer.subscriptions
+    end
+    render json: SubscriptionSerializer.new(subs)
+  end
+
   def create
     customer_data = Customer.find_by(email: params[:email])
     tea_data = Tea.find(params[:tea_id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,2 @@
 class ApplicationController < ActionController::API
-  def index
-    customer = Customer.find(params[:customer_id])
-    subs = customer.subscriptions
-    render json: SubscriptionSerializer.new(subs)
-  end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -2,4 +2,12 @@ class Customer < ApplicationRecord
   validates_presence_of :first_name, :last_name, :email, :address, presence: true
   has_many :subscriptions
   has_many :teas, through: :subscriptions
+
+  def get_active_subscriptions
+    subscriptions.where(status: :active)
+  end
+
+  def get_cancelled_subscriptions
+    subscriptions.where(status: :cancelled)
+  end
 end

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -96,5 +96,74 @@ RSpec.describe 'Subscription API Endpoints' do
         expect(subscription[:attributes]).to have_key(:frequency)
       end
     end
+
+    it 'will return only the active subscriptions when the param is set to true' do
+      c1 = Customer.create(first_name: "Test", last_name: "Person1", email: "test@person1.com", address: "12345 Something Road")
+
+      t1 = Tea.create(title: "Earl Grey", description: "Black Tea", temperature: 110, brew_time: 3)
+      t2 = Tea.create(title: "Green", description: "Green Tea", temperature: 100, brew_time: 5)
+      t3 = Tea.create(title: "Mint", description: "Mint Tea", temperature: 103, brew_time: 8)
+      t4 = Tea.create(title: "Matcha", description: "Matcha Tea", temperature: 107, brew_time: 9)
+
+      Subscription.create(title: t1.title, price: 10.00, status: 0, frequency: 1, tea_id: t1.id, customer_id: c1.id)
+      Subscription.create(title: t2.title, price: 10.00, status: 0, frequency: 1, tea_id: t2.id, customer_id: c1.id)
+      Subscription.create(title: t3.title, price: 10.00, status: 1, frequency: 1, tea_id: t3.id, customer_id: c1.id)
+
+      get '/api/v1/subscriptions', params: { customer_id: c1.id, status: "active" }
+      result = JSON.parse(response.body, symbolize_names: true)
+      expect(response).to be_successful
+
+      expect(result).to be_a Hash
+
+      expect(result).to have_key(:data)
+      expect(result[:data]).to be_an Array
+      expect(result[:data].count).to eq(2)
+
+      result[:data].each do |subscription|
+        expect(subscription).to have_key(:id)
+        expect(subscription).to have_key(:type)
+        expect(subscription[:type]).to eq("subscription")
+        expect(subscription).to have_key(:attributes)
+        expect(subscription[:attributes]).to have_key(:id)
+        expect(subscription[:attributes]).to have_key(:title)
+        expect(subscription[:attributes]).to have_key(:price)
+        expect(subscription[:attributes]).to have_key(:status)
+        expect(subscription[:attributes]).to have_key(:frequency)
+      end
+    end
+
+    it 'will only return cancelled subscriptions when the param is set to false' do
+      c1 = Customer.create(first_name: "Test", last_name: "Person1", email: "test@person1.com", address: "12345 Something Road")
+
+      t1 = Tea.create(title: "Earl Grey", description: "Black Tea", temperature: 110, brew_time: 3)
+      t2 = Tea.create(title: "Green", description: "Green Tea", temperature: 100, brew_time: 5)
+      t3 = Tea.create(title: "Mint", description: "Mint Tea", temperature: 103, brew_time: 8)
+      t4 = Tea.create(title: "Matcha", description: "Matcha Tea", temperature: 107, brew_time: 9)
+
+      Subscription.create(title: t1.title, price: 10.00, status: 0, frequency: 1, tea_id: t1.id, customer_id: c1.id)
+      Subscription.create(title: t2.title, price: 10.00, status: 0, frequency: 1, tea_id: t2.id, customer_id: c1.id)
+      Subscription.create(title: t3.title, price: 10.00, status: 1, frequency: 1, tea_id: t3.id, customer_id: c1.id)
+
+      get '/api/v1/subscriptions', params: { customer_id: c1.id, status: "cancelled" }
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(result).to be_a Hash
+
+      expect(result).to have_key(:data)
+      expect(result[:data]).to be_an Array
+      expect(result[:data].count).to eq(1)
+
+      result[:data].each do |subscription|
+        expect(subscription).to have_key(:id)
+        expect(subscription).to have_key(:type)
+        expect(subscription[:type]).to eq("subscription")
+        expect(subscription).to have_key(:attributes)
+        expect(subscription[:attributes]).to have_key(:id)
+        expect(subscription[:attributes]).to have_key(:title)
+        expect(subscription[:attributes]).to have_key(:price)
+        expect(subscription[:attributes]).to have_key(:status)
+        expect(subscription[:attributes]).to have_key(:frequency)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What changed?
- The endpoint to get all user subscriptions can be filtered by active or inactive subscriptions.