### PR TITLE
Fix sub create

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
   def create
-    customer_data = Customer.find_by(email: params[:email])
+    customer_data = Customer.find(params[:customer_id])
     tea_data = Tea.find(params[:tea_id])
     if customer_data.valid? && tea_data.valid?
       sub = Subscription.create(title: tea_data.title, price: 10, frequency: 1, customer_id: customer_data.id, tea_id: tea_data.id)

--- a/spec/requests/api/v1/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscription_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Subscription API Endpoints' do
       tea_data = 1
       c1 = Customer.create(first_name: "Test", last_name: "Person1", email: "test@person1.com", address: "12345 Something Road")
       t1 = Tea.create(title: "Earl Grey", description: "Black Tea", temperature: 110, brew_time: 3)
-      post "/api/v1/customers/#{c1.id}/subscriptions", params: { email: c1.email, tea_id: t1.id }
+      post "/api/v1/customers/#{c1.id}/subscriptions", params: { customer_id: c1.id, tea_id: t1.id }
       result = JSON.parse(response.body, symbolize_names: true)
 
       expect(response).to be_successful


### PR DESCRIPTION
## What changed?
- Modified the request spec for subscription creation to take a user ID instead of a user email which was set up that way in the initial design.
- Modified the process to create a subscription to only allow a user ID to be passed.